### PR TITLE
fix: remove hashValue for swift >= 4.2

### DIFF
--- a/Sources/TypeDecoder/TypeDecoder.swift
+++ b/Sources/TypeDecoder/TypeDecoder.swift
@@ -292,7 +292,6 @@ extension TypeInfo: CustomStringConvertible {
     }
 }
 
-
 extension TypeInfo: Hashable {
     #if swift(>=4.2)
     public func hash(into hasher: inout Hasher) {

--- a/Sources/TypeDecoder/TypeDecoder.swift
+++ b/Sources/TypeDecoder/TypeDecoder.swift
@@ -292,8 +292,13 @@ extension TypeInfo: CustomStringConvertible {
     }
 }
 
+
 extension TypeInfo: Hashable {
-    #if !swift(>=4.2)
+    #if swift(>=4.2)
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(description)
+    }
+    #else
     public var hashValue: Int {
         return description.hashValue
     }

--- a/Sources/TypeDecoder/TypeDecoder.swift
+++ b/Sources/TypeDecoder/TypeDecoder.swift
@@ -293,9 +293,11 @@ extension TypeInfo: CustomStringConvertible {
 }
 
 extension TypeInfo: Hashable {
+    #if !swift(>=4.2)
     public var hashValue: Int {
         return description.hashValue
     }
+    #endif
 }
 
 extension TypeInfo: Equatable {


### PR DESCRIPTION
Support for automatic synthesis of Hashable conformance has been added in Swift 4.2. This means we don't need to implement Hashvalue and will get a warning if we do as raising in issue #18.

This pull requests removes the Hashvalue implementation for Swift 4.2 and above.