### PR TITLE
Update tools-version to 4.2

### DIFF
--- a/Package@swift-4.0.swift
+++ b/Package@swift-4.0.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:4.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package@swift-4.1.swift
+++ b/Package@swift-4.1.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:4.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
Updates the tools-version for the default Package.swift to 4.2, in order to compile at language version 4.2 with Swift 4.2 or higher, removing the deprecation warning relating to Hashable.

Resolves #21 