### PR TITLE
fix: Correct name of ValidKeyedCodingValueProvider in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,8 +253,8 @@ public class YoungAdult: Codable {
 }
 
 // Provide a value for 'age' which is within the acceptable range
-extension YoungAdult: DummyKeyedCodingValueProvider {
-    public static func dummyCodingValue(forKey key: CodingKey) -> Any? {
+extension YoungAdult: ValidKeyedCodingValueProvider {
+    public static func validCodingValue(forKey key: CodingKey) -> Any? {
         switch key.stringValue {
         case self.CodingKeys.age.stringValue:
             return 20


### PR DESCRIPTION
https://github.com/IBM-Swift/TypeDecoder/pull/13 renamed and made public a pair of protocols, however one code example in the readme was missed and still refers to `DummyKeyedCodingValueProvider`, which will not compile.  This PR corrects the naming.